### PR TITLE
feature. update asset server config.

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,14 @@ $ node utils/getBundleCss.js
 
 ### 开发环境
 
+0. 启动静态文件代理
+
+```bash
+$ npm run dev-assets
+```
+
+这一步会将`assets`目录代理到`http://0.0.0.0:8889`以给下面的server使用
+
 1. 打开Webpack-dev-server，这可以让我们的app代码时实时更新，替换样式之类的再也不用重启app啦！
 
 ```bash

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "dev-app": "electron ./electron/main.js DEV",
     "dev-file": "webpack-dev-server --progress --colors --display-error-details --inline --hot --content-base root/build --config webpack/webpack.dev.config.js",
+    "dev-assets": "http-server ./ -p 8889",
     "deploy-app": "electron ./electron/main.js DEPLOY",
     "deploy-file": "NODE_ENV=production webpack -p --display-error-details --config webpack/webpack.deploy.config.js"
   },
@@ -23,8 +24,6 @@
   },
   "homepage": "https://github.com/sekaiamber/web-painter#readme",
   "devDependencies": {
-    "glob": "^7.0.5",
-    "electron-prebuilt": "^1.2.0",
     "autoprefixer-loader": "3.2.0",
     "babel-core": "6.6.0",
     "babel-jest": "11.0.2",
@@ -34,8 +33,11 @@
     "babel-preset-es2015": "6.6.0",
     "babel-preset-react": "6.5.0",
     "babel-preset-react-hmre": "1.1.1",
+    "copy-webpack-plugin": "^3.0.1",
     "css-loader": "0.23.1",
+    "electron-prebuilt": "^1.2.0",
     "file-loader": "0.8.5",
+    "glob": "^7.0.5",
     "gulp": "^3.9.1",
     "html-webpack-plugin": "2.12.0",
     "img-loader": "1.2.2",
@@ -51,7 +53,8 @@
     "style-loader": "0.13.0",
     "url-loader": "0.5.7",
     "webpack": "^1.13.2",
-    "webpack-dev-server": "^1.15.1"
+    "webpack-dev-server": "^1.15.1",
+    "http-server": "^0.9.0"
   },
   "dependencies": {
     "antd": "^1.8.0",

--- a/webpack/webpack.deploy.config.js
+++ b/webpack/webpack.deploy.config.js
@@ -4,6 +4,7 @@ var ExtractTextPlugin = require("extract-text-webpack-plugin");
 var HtmlWebpackPlugin = require('html-webpack-plugin');
 var uglifyJsPlugin = webpack.optimize.UglifyJsPlugin;
 var CommonsChunkPlugin = webpack.optimize.CommonsChunkPlugin;
+var CopyWebpackPlugin = require('copy-webpack-plugin');
 var routes = require('./routes');
 
 var config = {
@@ -42,6 +43,9 @@ var config = {
       minSizeReduce: 1.5,
       moveToParents: true
     }),
+    new CopyWebpackPlugin([
+      { from: '../assets', to: 'assets' },
+    ])
   ],
   // node: {
   //   fs: "empty"

--- a/webpack/webpack.dev.config.js
+++ b/webpack/webpack.dev.config.js
@@ -73,11 +73,11 @@ var config = {
       index: 'index.html',
       rewrites: []
     },
-    // proxy: {
-    //   '/api/web/v1/*': {
-    //     target: 'https://dsjstage.bao.tv',
-    //     secure: false
-    //   },
+    proxy: {
+      '/assets/*': {
+        target: 'http://0.0.0.0:8889',
+        secure: false
+      },
     //   '/_dev_api_/*': {
     //     target: 'http://106.75.8.227',
     //     secure: false,
@@ -85,7 +85,7 @@ var config = {
     //       req.url = req.url.replace(/^\/_dev_api_/, '');
     //     }
     //   }
-    // }
+    }
   },
 };
 


### PR DESCRIPTION
这个PR增加了静态文件代理的设置：
- 在deploy的时候，会将`assets`目录复制到`dist/assets`
- 同样，在dev环境下，我们需要将`http://0.0.0.0:8888/assets`代理到`assets`目录，所以我增加了一个代理服务器，这个服务器启动为`npm run dev-assets`将占用8889端口，并且8888端口的相应请求会代理到8889端口
