### PR TITLE
bugfix. carousel pattern export id.

### DIFF
--- a/app/utils/pageEditor/pagePattern.js
+++ b/app/utils/pageEditor/pagePattern.js
@@ -12,7 +12,11 @@ export default class PagePattern {
 
   // init
   initDom(patternReactComponentClass) {
-    let $pattern = $(patternReactComponentClass.plainHtmlText).addClass('pe-pattern');
+    let plainHtmlText = patternReactComponentClass.plainHtmlText;
+    if (typeof plainHtmlText == 'function') {
+      plainHtmlText = plainHtmlText();
+    }
+    let $pattern = $(plainHtmlText).addClass('pe-pattern');
     if (patternReactComponentClass.domDidAdd) {
       patternReactComponentClass.domDidAdd($pattern);
     }

--- a/app/workspace/selectMode/patternBar/patternGroups/carousels/patterns/carousel-heading-paragraph.jsx
+++ b/app/workspace/selectMode/patternBar/patternGroups/carousels/patterns/carousel-heading-paragraph.jsx
@@ -1,4 +1,5 @@
 let React = require('react');
+const crypto = require('crypto');
 let htmlTemplate = require('./../../../../../../htmlTemplates/patterns/carousels/carousel-heading-paragraph.html');
 require('./../../../../../../htmlTemplates/patterns/carousels/carousel-heading-paragraph.scss');
 import $ from 'jquery'
@@ -24,7 +25,9 @@ export default class CarouselHeadingParagraphPattern extends Pattern {
 }
 CarouselHeadingParagraphPattern.patternTag = 'carousel-heading-paragraph';
 CarouselHeadingParagraphPattern.attributeGroups = attributeGroups;
-CarouselHeadingParagraphPattern.plainHtmlText = htmlTemplate;
+CarouselHeadingParagraphPattern.plainHtmlText = function () {
+  return htmlTemplate.replace(/@id/g, crypto.createHash('md5').update(`${Date.now()}_${Math.random}`).digest("hex"));
+}
 CarouselHeadingParagraphPattern.domDidAdd = function ($dom) {
   $('.wp-carousel', $dom).carousel();
 }


### PR DESCRIPTION
这个PR修复了Carousel pattern不会替换id的bug，顺便规定了Pattern.plainHtmlText可以为一个函数，如果是函数则执行之后再添加
