### PR TITLE
bugfix. `a` element export process.

### DIFF
--- a/app/utils/ipc/export/htmlExportHandler/a.js
+++ b/app/utils/ipc/export/htmlExportHandler/a.js
@@ -15,7 +15,7 @@ export default {
     } else {
       // link to URL
       let href = $dom.attr('href');
-      if (!href.startsWith('http')) {
+      if (!href.startsWith('http') && !href.startsWith('#')) {
         $dom.attr('href', `http://${$dom.attr('href')}`)
       }
     }


### PR DESCRIPTION
修复了a元素href为#开头情况下会被加上http协议前缀的bug
