### PR TITLE
bugfix. save project compress file fail.

### DIFF
--- a/app/utils/ipc/save.js
+++ b/app/utils/ipc/save.js
@@ -1,16 +1,17 @@
 const ipc = require('electron').ipcRenderer
 const nativeImage = require('electron').nativeImage
-var AdmZip = require('adm-zip');
+const archiver = require('archiver');
+const fs = require('fs');
 import fshelper from './../fs'
 import $ from 'jquery';
 
 // zip
 function createZipfile(files) {
-  var zip = new AdmZip();
+  var zip = archiver.create('zip', {});
   for (var i = 0; i < files.length; i++) {
-    var file = files[i];
-    zip.addFile(file.name, file.data)
-  };
+    var file = files[i]
+    zip.append(file.data, {'name': file.name});
+  }
   return zip;
 }
 
@@ -45,12 +46,13 @@ ipc.on('save-project', function (event, filename) {
   })
   files = files.concat(assets);
 
-  let zip = createZipfile(files);
-  // let zip = createZipfile({
-  //   name: 'assets/aaa.jpg',
-  //   data: nativeImage.createFromPath('/Volumes/disk02/web-painter/assets/images/sekai.jpg').toPNG()
-  // })
+  var output = fs.createWriteStream(filename);
+  output.on('close', function() {
+    console.log(`[save project]: save project to ${filename}`)
+  });
 
-  zip.writeZip(filename);
-  console.log(`[save project]: save project to ${filename}`)
+  let zipArchiver = createZipfile(files);
+  zipArchiver.pipe(output);
+
+  zipArchiver.finalize();
 })

--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
     "react-dom": "0.14.7",
     "react-router": "2.0.0",
     "adm-zip": "^0.4.7",
-    "bootstrap": "3.3.7"
+    "bootstrap": "3.3.7",
+    "archiver": "^1.1.0"
   }
 }


### PR DESCRIPTION
#81 修复了压缩错误的bug，这个bug会导致用户Asset无法正确压缩到项目文件中，原本在#81中以为是大文件的关系，最后发现这是adm-zip这个库本身的bug：

经测试，用裸库加载某些文件确实无法压缩到文件中，经调查确实存在这样的情况。

压缩过程换用了[archiver](https://github.com/archiverjs/node-archiver)作为工具库，目前看来这是node里最稳定的压缩库，然而美中不足是无法提供解压缩的过程，所以解压缩还是由adm-zip负责。

原本就是看中adm-zip既能压缩又能解压，结果有bug，坑爹啊。
