### PR TITLE
feature. udpate attribute handler.

### DIFF
--- a/app/utils/pageEditor/attributeHandler/attributes/carousel.js
+++ b/app/utils/pageEditor/attributeHandler/attributes/carousel.js
@@ -2,15 +2,6 @@ import $ from 'jquery'
 import imageattrs from './image'
 import attrattrs from './attr'
 
-const colMap = {
-  1: 4,
-  2: 4,
-  3: 4,
-  4: 3,
-  5: 2,
-  6: 2
-}
-
 let carouselWithThumbnails = {
   set($dom, value) {
     $('.carousel-thumbnails', $dom).remove();

--- a/app/utils/pageEditor/attributeHandler/attributes/css.js
+++ b/app/utils/pageEditor/attributeHandler/attributes/css.js
@@ -16,7 +16,8 @@ cssKeys.map((key) => {
     },
     get($dom) {
       return $dom.css(key)
-    }
+    },
+    useStorage: true
   }
 })
 

--- a/app/utils/pageEditor/attributeHandler/pageAttribute.js
+++ b/app/utils/pageEditor/attributeHandler/pageAttribute.js
@@ -33,5 +33,30 @@ _.merge(attrs, deviceattrs);
 _.merge(attrs, rowattrs);
 _.merge(attrs, panelattrs);
 
+Object.keys(attrs).map((key) => {
+  let attr = attrs[key];
+  // set
+  let setf = attr.set;
+  attr._set = setf;
+  attr.set = function() {
+    this._set.apply(this, arguments);
+    let $dom  = arguments[0];
+    $dom.data(key, arguments[1]);
+  }
+  // get
+  let getf = attr.get;
+  attr._get = getf;
+  attr.get = function() {
+    if (this.useStorage) {
+      let ret = arguments[0].data(key);
+      if (ret == undefined) {
+        ret = this._get.apply(this, arguments);
+      }
+      return ret;
+    } else {
+      return this._get.apply(this, arguments);
+    }
+  }
+})
 
 export default attrs;


### PR DESCRIPTION
这个PR十分重要，解决了 #119 #120 

原本，对于某个设置项，内部实现是使用`get`和`set`，它们直接通过操作dom元素来实现，一些复杂的操作`get`会通过分析dom来做。

当前改为了，`set`行为不变，但是外面包裹了一层，将数据存到`$dom.data()`本身上，而`get`被覆盖，从`$dom.data()`上读取，若读取不到（比如新打开文件或默认误操作），则通过分析dom来读取

这一定程度上增加了`get`操作的速度，并可以使得 #119 #120 这样的bug得以解决

这个PR将在`v0.0.2`被修复
